### PR TITLE
Incrementato `read-timeout` per il client Feign `result-service` a 60…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,7 @@ spring.cloud.openfeign.client.config.conductor-client.connect-timeout=5000
 spring.cloud.openfeign.client.config.conductor-client.read-timeout=300000
 
 spring.cloud.openfeign.client.config.result-service-client.connect-timeout=5000
-spring.cloud.openfeign.client.config.result-service-client.read-timeout=300000
+spring.cloud.openfeign.client.config.result-service-client.read-timeout=600000
 
 spring.cloud.openfeign.client.config.result-aggregator-service-client.connect-timeout=5000
 spring.cloud.openfeign.client.config.result-aggregator-service-client.read-timeout=300000


### PR DESCRIPTION
…0000 ms.